### PR TITLE
Update package.json to MIT license

### DIFF
--- a/Content/Scripts/package.json
+++ b/Content/Scripts/package.json
@@ -8,7 +8,7 @@
     "watch": "babel --watch demos/src -d demos/build"
   },
   "author": "NCSOFT",
-  "license": "ISC",
+  "license": "MIT",
   "description": "",
   "dependencies": {
     "convnetjs": "^0.3.0",


### PR DESCRIPTION
The main Unreal.js-demo project uses the MIT license. This looks like a default "npm init" value that wasn't updated.