### PR TITLE
Add eslint devDependency

### DIFF
--- a/Content/Scripts/package.json
+++ b/Content/Scripts/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "babel-cli": "^6.6.4",
     "babel-eslint": "^5.0.0",
-    "babel-preset-react": "^6.5.0"
+    "babel-preset-react": "^6.5.0",
+    "eslint": "<2.3.0"
   }
 }


### PR DESCRIPTION
npm WARN babel-eslint@5.0.4 requires a peer of eslint@<2.3.0 but none was installed.